### PR TITLE
Consolidate Input and Import types

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,27 @@
+let
+  nixpkgs = builtins.fetchTarball {
+    url    = "https://github.com/NixOS/nixpkgs/archive/e0ce3c683ae677cf5aab597d645520cddd13392b.tar.gz";
+    sha256 = "08ans3w6r4fbs1wx6lzlp4xwhy6p04x3spvvrjz5950w8mzxqm61";
+  };
+
+  overlay = pkgsNew: pkgsOld: {
+    haskellPackages = pkgsOld.haskellPackages.override (old: {
+      overrides =
+        let
+          oldOverrides = old.overrides or (_: _: {});
+
+          sourceOverrides = pkgsNew.haskell.lib.packageSourceOverrides {
+            grace = ./grace;
+
+            grace-core = ./grace-core;
+          };
+
+        in
+          pkgsNew.lib.composeExtensions oldOverrides sourceOverrides;
+    });
+  };
+
+  pkgs = import nixpkgs { config = { }; overlays = [ overlay ]; };
+
+in
+  { inherit (pkgs.haskellPackages) grace-core grace; }

--- a/grace-core/shell.nix
+++ b/grace-core/shell.nix
@@ -2,4 +2,4 @@ let
   pkgs = import <nixpkgs> { config = { allowBroken = true; }; overlays = []; };
 
 in
-  (pkgs.haskellPackages.callCabal2nix "grace" ./. { }).env
+  (pkgs.haskellPackages.callCabal2nix "grace-core" ./. { }).env

--- a/grace-core/shell.nix
+++ b/grace-core/shell.nix
@@ -1,5 +1,1 @@
-let
-  pkgs = import <nixpkgs> { config = { allowBroken = true; }; overlays = []; };
-
-in
-  (pkgs.haskellPackages.callCabal2nix "grace-core" ./. { }).env
+(import ../default.nix).grace-core.env

--- a/grace-core/src/Grace/TH.hs
+++ b/grace-core/src/Grace/TH.hs
@@ -97,7 +97,7 @@ typeOfInput = helperFunction fst
 
 helperFunction :: Lift r => ((Type (), Syntax () Void) -> r) -> Input -> Q (TExp r)
 helperFunction f input = do
-    eitherResult <- Except.runExceptT (Interpret.interpret Nothing input)
+    eitherResult <- Except.runExceptT (Interpret.interpret input)
 
     (inferred, value) <- case eitherResult of
         Left e -> fail (displayException e)

--- a/grace-core/tasty/Grace/Test/Resolver.hs
+++ b/grace-core/tasty/Grace/Test/Resolver.hs
@@ -24,7 +24,7 @@ import qualified System.Environment   as Environment
 import qualified Test.Tasty.HUnit     as Tasty.HUnit
 
 interpret :: Input -> IO (Either InterpretError (Type Location, Value.Value))
-interpret input = Except.runExceptT (Interpret.interpret Nothing input)
+interpret input = Except.runExceptT (Interpret.interpret input)
 
 interpretCodeWithEnvURI :: TestTree
 interpretCodeWithEnvURI = Tasty.HUnit.testCase "interpret code with env:// import" do
@@ -37,7 +37,8 @@ interpretCodeWithEnvURI = Tasty.HUnit.testCase "interpret code with env:// impor
     let expectedValue =
             Right (Type{ location, node }, Value.Scalar (Syntax.Bool True))
           where
-            location = Location{ name = uri, code = "true", offset = 0 }
+            -- TODO: Make the location match the grammar
+            location = Location{ name = "env:GRACE_TEST_VAR", code = "true", offset = 0 }
 
             node = Type.Scalar Monotype.Bool
 
@@ -54,7 +55,7 @@ interpretCodeWithFileURI = Tasty.HUnit.testCase "interpret code with file:// imp
     let expectedValue =
             Right (Type{ location, node }, Value.Scalar (Syntax.Bool True))
           where
-            location = Location{ name = uri, code = "true\n", offset = 0 }
+            location = Location{ name = absolute, code = "true\n", offset = 0 }
 
             node = Type.Scalar Monotype.Bool
 

--- a/grace-core/tasty/Main.hs
+++ b/grace-core/tasty/Main.hs
@@ -36,7 +36,7 @@ pretty_ x =
         (pretty x <> Pretty.hardline)
 
 interpret :: Input -> IO (Either InterpretError (Type Location, Value.Value))
-interpret input = Except.runExceptT (Interpret.interpret Nothing input)
+interpret input = Except.runExceptT (Interpret.interpret input)
 
 fileToTestTree :: FilePath -> IO TestTree
 fileToTestTree prefix = do

--- a/grace/shell.nix
+++ b/grace/shell.nix
@@ -1,5 +1,1 @@
-let
-  pkgs = import <nixpkgs> { config = { allowBroken = true; }; overlays = []; };
-
-in
-  (pkgs.haskellPackages.callCabal2nix "grace" ./. { }).env
+(import ../default.nix).grace.env


### PR DESCRIPTION
This simplifies the code in three ways:

* You no longer need separate `Input` and `Import` types
* You no longer need separate `interpretWith` / `interpretExprWith` functions
* The `parseInput` function turns into just another resolver